### PR TITLE
Fix build

### DIFF
--- a/bin/venv_update.py
+++ b/bin/venv_update.py
@@ -55,11 +55,23 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
 from os.path import exists
 from os.path import join
 from subprocess import CalledProcessError
 
-__version__ = '3.1.1'
+# https://github.com/Yelp/venv-update/issues/227
+# https://stackoverflow.com/a/53193892
+# On OS X, Python "framework" builds set a `__PYVENV_LAUNCHER__` environment
+# variable when executed, which gets inherited by child processes and cause
+# certain Python builds to put incorrect packages onto their path. This causes
+# weird bugs with venv-update like import errors calling pip and infinite
+# exec() loops trying to activate a virtualenv.
+#
+# To fix this we just delete the environment variable.
+os.environ.pop('__PYVENV_LAUNCHER__', None)
+
+__version__ = '3.2.4'
 DEFAULT_VIRTUALENV_PATH = 'venv'
 DEFAULT_OPTION_VALUES = {
     'venv=': (DEFAULT_VIRTUALENV_PATH,),
@@ -199,6 +211,7 @@ def exec_scratch_virtualenv(args):
     if not exists(join(scratch.src, 'virtualenv.py')):
         scratch_python = venv_python(scratch.venv)
         # TODO: do we allow user-defined override of which version of virtualenv to install?
+        # https://github.com/Yelp/venv-update/issues/231 virtualenv 20+ is not supported.
         tmp = scratch.src + '.tmp'
         run((scratch_python, '-m', 'pip.__main__', 'install', 'virtualenv<20', '--target', tmp))
 
@@ -257,7 +270,7 @@ def invalid_virtualenv_reason(venv_path, source_python, destination_python, opti
     except CalledProcessError:
         return 'could not inspect metadata'
     if not samefile(orig_path, venv_path):
-        return 'virtualenv moved %s -> %s' % (timid_relpath(orig_path), timid_relpath(venv_path))
+        return 'virtualenv moved {} -> {}'.format(timid_relpath(orig_path), timid_relpath(venv_path))
     elif has_system_site_packages(destination_python) != options.system_site_packages:
         return 'system-site-packages changed, to %s' % options.system_site_packages
 
@@ -266,7 +279,7 @@ def invalid_virtualenv_reason(venv_path, source_python, destination_python, opti
     destination_version = get_python_version(destination_python)
     source_version = get_python_version(source_python)
     if source_version != destination_version:
-        return 'python version changed %s -> %s' % (destination_version, source_version)
+        return 'python version changed {} -> {}'.format(destination_version, source_version)
 
 
 def ensure_virtualenv(args, return_values):

--- a/pytest_antilru/main.py
+++ b/pytest_antilru/main.py
@@ -5,8 +5,14 @@ from functools import wraps  # pylint: disable=ungrouped-imports
 
 import pytest
 
-if not hasattr(functools, 'lru_cache'):  # pragma: no cover
-    # Several py2 backport packages
+# Python 3.2 introduced lru_cache to functools
+IS_PY3 = hasattr(functools, 'lru_cache')
+
+if not IS_PY3:  # pragma: no cover
+    # Ignore linting and test coverage for this py2 only code section
+    # pylint: disable=raise-missing-from
+
+    # There are several py2 backport packages to attempt to load
     try:
         import backports.functools_lru_cache as functools
     except ImportError:

--- a/requirements-bootstrap.txt
+++ b/requirements-bootstrap.txt
@@ -2,5 +2,5 @@ pip==18.1.0
 pip-custom-platform==0.3.1
 pymonkey==0.2.2
 venv-update==3.2.0
-virtualenv==16.4.0
+virtualenv==20.0.33
 wheel==0.33.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 black; python_version >= '3.6'
 flake8
+# tox constraint
+importlib-metadata < 2
 ipython
 pre-commit
 pudb


### PR DESCRIPTION
There were new python dependency update that have broken the build.
* update venv-update
* bump virtualenv bootstrap requirement
* Disable linting for py2 section (likely pylint update that made warnings failures)