### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,7 +3,10 @@
 
 name: Python package
 
-on: push
+on:
+  push:
+  schedule:
+    - cron: '0 2 * * SAT'
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "2.7"
           - "3.5"
           - "3.6"
           - "3.7"
@@ -21,8 +20,6 @@ jobs:
           - "3.9"
         include:
           - os: ubuntu-latest
-          - os: ubuntu-20.04
-            python-version: "2.7"
           - os: ubuntu-20.04
             python-version: "3.5"
           - os: ubuntu-20.04

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,10 @@ deps =
     pytest6: pytest==6.*
     pytest7: pytest~=7.0.0rc1
     coverage
-passenv = HOME SSH_AUTH_SOCK USER
+passenv =
+    HOME
+    SSH_AUTH_SOCK
+    USER
 commands =
     coverage run -m pytest tests/main_test.py::test_a_run_first tests/main_test.py::test_b_run_second
     coverage run -m pytest tests/main_test.py


### PR DESCRIPTION
Tests are broken because of infrastructure changes:
- setup-python action deprecated python 2.7, so removing support for testing that
- tox 4 [requires migration of tox.ini](https://tox.wiki/en/stable/upgrading.html#changed-ini-rules)

Fixes #31 