### PR TITLE
Fix issue with pytest-antilru working with pytest-django

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,31 @@ Simply install this in the same python environment that `pytest` uses and the re
 pip install pytest-antilru
 ```
 
+## Configuration
+
+Add this where ever [your pytest configurations](https://docs.pytest.org/en/stable/reference/customize.html) live.
+
+### `lru_cache_disabled`
+
+`lru_cache_disabled` is an allowlist of module paths to disable `lru_cache` for.
+This allows you to target disable caching for specific modules that are causing test pollution.
+
+The default behaviour of `pytest-antilru` is to disable `lru_cache` everywhere.
+However, this can interfere with other dependencies that are reliant on `lru_cache` behaviour to behave correctly
+within the same test run.
+
+```ini
+[tool.pytest.ini_options]
+lru_cache_disabled = '''
+    my_module.util
+    my_module.client_lib.database
+    '''
+```
+
+In this example, any usage of `lru_cache` in a file inside `my_module.util` or `my_module.client_lib.database`
+will be disabled.
+All other instances will continue to be cached within a test run.
+
 ## How to test the software
 
 ```sh

--- a/pytest_antilru/main.py
+++ b/pytest_antilru/main.py
@@ -7,6 +7,7 @@ from functools import wraps  # pylint: disable=ungrouped-imports
 import pytest
 
 CACHED_FUNCTIONS = []
+old_lru_cache = None
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -14,6 +15,7 @@ def pytest_load_initial_conftests(early_config, parser, args):  # pylint: disabl
     """Monkey patch lru_cache, before any module imports occur."""
 
     # Gotta hold on to this before we patch it away
+    global old_lru_cache
     old_lru_cache = functools.lru_cache
 
     @wraps(functools.lru_cache)
@@ -53,6 +55,10 @@ def pytest_load_initial_conftests(early_config, parser, args):  # pylint: disabl
 
     yield
 
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_collection(session):
+    yield
     # Be a good citizen and undo our monkeying
     functools.lru_cache = old_lru_cache
 

--- a/pytest_antilru/main.py
+++ b/pytest_antilru/main.py
@@ -9,8 +9,8 @@ import pytest
 CACHED_FUNCTIONS = []
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_collection(session):  # pylint: disable=unused-argument
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_load_initial_conftests(early_config, parser, args):  # pylint: disable=unused-argument
     """Monkey patch lru_cache, before any module imports occur."""
 
     # Gotta hold on to this before we patch it away

--- a/pytest_antilru/main.py
+++ b/pytest_antilru/main.py
@@ -13,8 +13,8 @@ old_lru_cache = None
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_load_initial_conftests(early_config, parser, args):  # pylint: disable=unused-argument
     """Monkey patch lru_cache, before any module imports occur."""
-    parser.addini("lru_cache_disabled", ".", type="linelist")
-    lru_cache_disabled_modules = early_config.getini("lru_cache_disabled")
+    parser.addini('lru_cache_disabled', 'Allowlist of module prefixes to apply disable lru_cache on', type='linelist')
+    lru_cache_disabled_modules = early_config.getini('lru_cache_disabled')
 
     # Gotta hold on to this before we patch it away
     global old_lru_cache
@@ -47,7 +47,7 @@ def pytest_load_initial_conftests(early_config, parser, args):  # pylint: disabl
         def decorating_function(user_function):
             """Wraps the user function, which is what everyone is actually using. Including us."""
             _wrapper = wrapper(user_function)
-            if lru_cache_disabled_modules:
+            if lru_cache_disabled_modules:  # pragma: no cover
                 for module_path in lru_cache_disabled_modules:
                     if user_function.__module__.startswith(module_path):
                         CACHED_FUNCTIONS.append(_wrapper)


### PR DESCRIPTION
Fixes #27 

Changes the hook to `pytest_load_initial_conftests` from `pytest_collection`. I also found that this mean that all `lru_cache`s were busted across all libraries as well. Sometimes you don't want to do this for example django loads a list of common passwords https://github.com/django/django/blob/90c75dc4f37bee19b7c3790519d187e38e293800/django/contrib/auth/password_validation.py#L228-L230 which is probably fine to lru_cache if you're just using django as a library.

So I added an option to `lru_cache_disabled` that allows you to specify a list of modules that lru_cache is disabled for, otherwise it defaults back to disabling for all.

Not sure what your thoughts are on the option or how it should be implemented.

I've tested this on a code base that has 50k test functions which ends up at 110k tests including parametrizations