### PR TITLE
Allow manually triggering github workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ name: Tests
 
 on:
   push:
+  workflow_dispatch:
   schedule:
     - cron: '0 2 * * SAT'
 


### PR DESCRIPTION
Add `workflow_dispatch` event to trigger.
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

> To enable a workflow to be **triggered manually**, you need to configure the workflow_dispatch event. You can manually trigger a workflow run using the GitHub API, GitHub CLI, or **GitHub browser interface**. 