### PR TITLE
Update github tests to run on pull requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,7 @@ name: Tests
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 2 * * SAT'


### PR DESCRIPTION
Fixes #38

`push` is only useful for commits that are pushed to this repository. This is for direct collaborators, as well as all the branches that are maintained here (none). `pull_request` is the only one that works for PRs from forks.