### PR TITLE
Upperbound pin setuptools for pytest 3 and 4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,9 @@ python =
 [testenv]
 deps =
     pytest3: pytest==3
+    pytest3: setuptools<71
     pytest4: pytest==4
+    pytest4: setuptools<71
     pytest5: pytest==5
     pytest6: pytest==6
     pytest7: pytest==7


### PR DESCRIPTION
There are compatibility issues between pytest 3/4 and setuptools v71+.