### PR TITLE
docs: prune stale AGENTS.md content, add verified gotchas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,5 @@
 
 /.coverage
 
-# Dolt database files (added by bd init)
-.dolt/
-*.db
-
 # Secrets
 .env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,15 @@ value. `tox.ini` runs this pair under three configs, but only `pytest_lru_cache_
 actually exercises that assertion — the other two configs hit a `pytest.skip()` guard (empty
 allowlist, or an allowlist that already covers `tests.main_test`).
 
+## Plugin Internals Gotcha
+
+In `pytest_antilru/main.py`, `pytest_runtest_teardown` is registered with `tryfirst=True` as a
+hookwrapper specifically so its own cache-clearing code (after `yield`) runs last, once every other
+teardown hookwrapper and fixture has finished. That's why a cached value stays visible through a
+test's own fixture teardown but is gone by the next test — `tests/teardown_order_test.py` and its
+hookwrapper probe in `tests/conftest.py` lock in that ordering. Don't drop `tryfirst` or reorder this
+hook without re-verifying against both.
+
 ## Non-Interactive Shell Commands
 
 **ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+See `README.md` for what this plugin does, its compatibility matrix, and the Poetry→uv lockfile migration status.
 
 ## Preferred Make Targets
 
@@ -43,15 +43,18 @@ make build
 
 Right now `make build` delegates to `uv build`. Use the `make` target instead of `python -m build` so agents do not need to guess which packaging tool is active in this repo.
 
-## Quick Reference
+## Testing Gotchas
 
-```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --claim  # Claim work atomically
-bd close <id>         # Complete work
-bd sync               # Sync with git
-```
+`tests/main_test.py` follows a `test_a_run_first` / `test_b_run_second` naming convention: `test_a`
+warms the cache, `test_b` asserts it was busted. `tox.ini` deliberately runs this pair forward, then
+in reverse order, to prove cache-busting works regardless of execution order — don't reorder the
+`tox.ini` commands without preserving that check.
+
+`tests/allowlist_test.py` reuses `main_test.py`'s `test_a_run_first` but defines its own
+`test_b_run_second` with the opposite assertion: an allowlisted module should *keep* its cached
+value. `tox.ini` runs this pair under three configs, but only `pytest_lru_cache_allowlist_no_match.ini`
+actually exercises that assertion — the other two configs hit a `pytest.skip()` guard (empty
+allowlist, or an allowlist that already covers `tests.main_test`).
 
 ## Non-Interactive Shell Commands
 
@@ -76,116 +79,3 @@ cp -rf source dest          # NOT: cp -r source dest
 - `ssh` - use `-o BatchMode=yes` to fail instead of prompting
 - `apt-get` - use `-y` flag
 - `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
-
-<!-- BEGIN BEADS INTEGRATION -->
-## Issue Tracking with bd (beads)
-
-**IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
-
-### Why bd?
-
-- Dependency-aware: Track blockers and relationships between issues
-- Version-controlled: Built on Dolt with cell-level merge
-- Agent-optimized: JSON output, ready work detection, discovered-from links
-- Prevents duplicate tracking systems and confusion
-
-### Quick Start
-
-**Check for ready work:**
-
-```bash
-bd ready --json
-```
-
-**Create new issues:**
-
-```bash
-bd create "Issue title" --description="Detailed context" -t bug|feature|task -p 0-4 --json
-bd create "Issue title" --description="What this issue is about" -p 1 --deps discovered-from:bd-123 --json
-```
-
-**Claim and update:**
-
-```bash
-bd update <id> --claim --json
-bd update bd-42 --priority 1 --json
-```
-
-**Complete work:**
-
-```bash
-bd close bd-42 --reason "Completed" --json
-```
-
-### Issue Types
-
-- `bug` - Something broken
-- `feature` - New functionality
-- `task` - Work item (tests, docs, refactoring)
-- `epic` - Large feature with subtasks
-- `chore` - Maintenance (dependencies, tooling)
-
-### Priorities
-
-- `0` - Critical (security, data loss, broken builds)
-- `1` - High (major features, important bugs)
-- `2` - Medium (default, nice-to-have)
-- `3` - Low (polish, optimization)
-- `4` - Backlog (future ideas)
-
-### Workflow for AI Agents
-
-1. **Check ready work**: `bd ready` shows unblocked issues
-2. **Claim your task atomically**: `bd update <id> --claim`
-3. **Work on it**: Implement, test, document
-4. **Discover new work?** Create linked issue:
-   - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
-5. **Complete**: `bd close <id> --reason "Done"`
-
-### Auto-Sync
-
-bd automatically syncs with git:
-
-- Exports to `.beads/issues.jsonl` after changes (5s debounce)
-- Imports from JSONL when newer (e.g., after `git pull`)
-- No manual export/import needed!
-
-### Important Rules
-
-- ✅ Use bd for ALL task tracking
-- ✅ Always use `--json` flag for programmatic use
-- ✅ Link discovered work with `discovered-from` dependencies
-- ✅ Check `bd ready` before asking "what should I work on?"
-- ❌ Do NOT create markdown TODO lists
-- ❌ Do NOT use external issue trackers
-- ❌ Do NOT duplicate tracking systems
-
-For more details, see README.md and docs/QUICKSTART.md.
-
-## Landing the Plane (Session Completion)
-
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
-
-**MANDATORY WORKFLOW:**
-
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
-   ```bash
-   git pull --rebase
-   bd sync
-   git push
-   git status  # MUST show "up to date with origin"
-   ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
-
-**CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
-
-<!-- END BEADS INTEGRATION -->


### PR DESCRIPTION
## What changed

`AGENTS.md` no longer instructs agents to run `bd` (beads) — that tooling was never
installed in this repo, so following those instructions would just fail. It now points
to `README.md` for architecture, the compatibility matrix, and the Poetry→uv migration
status instead of duplicating them. The leftover `.gitignore` entries for beads' Dolt
database files are removed too, since nothing in the repo references them anymore.

In their place, two gotchas that weren't written down anywhere:

- **Test ordering**: `tox.ini` runs `tests/main_test.py`'s cache-warm/cache-bust pair
  forward, then reversed, to prove cache-busting is order-independent — `tests/allowlist_test.py`
  reuses that pair's first half but asserts the opposite outcome (an allowlisted module
  keeps its cache), and only one of its three configured runs actually exercises that check.
- **Teardown hook ordering**: `pytest_runtest_teardown` is a `tryfirst=True` hookwrapper
  specifically so its cache-clearing runs after every other teardown hook/fixture — that's
  why a cached value survives a test's own fixture teardown but not into the next test.

## Why

An agent following the old `AGENTS.md` would try to run `bd` commands that don't exist
in this repo, and had no way to know the two test-ordering/hook-ordering invariants above
without reading `tox.ini` and `pytest_antilru/main.py` line by line first.

## Test plan

No behavior changed — this is documentation and `.gitignore` only. Verified every new
claim in `AGENTS.md` against the actual source it describes (`tox.ini`, `pytest_antilru/main.py`,
`tests/main_test.py`, `tests/allowlist_test.py`, `tests/teardown_order_test.py`, `tests/conftest.py`)
and confirmed no remaining references to `bd`/beads/Dolt anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2n19tqdeZ3dKXqJzGFLzt